### PR TITLE
Add null value handling for protobuf enums and messages

### DIFF
--- a/jackson-module-protobuf/src/main/java/jacksonmodule/protobuf/ProtobufEnumDeserializer.java
+++ b/jackson-module-protobuf/src/main/java/jacksonmodule/protobuf/ProtobufEnumDeserializer.java
@@ -3,8 +3,10 @@ package jacksonmodule.protobuf;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.protobuf.NullValue;
 import com.google.protobuf.ProtocolMessageEnum;
 import java.io.IOException;
 import java.util.HashMap;
@@ -44,6 +46,14 @@ final class ProtobufEnumDeserializer<T extends Enum<T> & ProtocolMessageEnum> ex
 
         throw new IllegalArgumentException(
                 "Can't deserialize protobuf enum '" + clazz.getSimpleName() + "' from " + treeNode);
+    }
+
+    @Override
+    public T getNullValue(DeserializationContext ctxt) throws JsonMappingException {
+        if (NullValue.class.isAssignableFrom(clazz)) {
+            return clazz.cast(NullValue.NULL_VALUE);
+        }
+        return super.getNullValue(ctxt);
     }
 
     private T[] getEnumConstants(Class<T> clazz) {

--- a/jackson-module-protobuf/src/main/java/jacksonmodule/protobuf/ProtobufMessageDeserializer.java
+++ b/jackson-module-protobuf/src/main/java/jacksonmodule/protobuf/ProtobufMessageDeserializer.java
@@ -3,8 +3,11 @@ package jacksonmodule.protobuf;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
+import com.google.protobuf.NullValue;
+import com.google.protobuf.Value;
 import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -38,6 +41,18 @@ final class ProtobufMessageDeserializer<T extends MessageOrBuilder> extends Json
         options.parser().merge(json, builder);
 
         return (T) builder.build();
+    }
+
+    @Override
+    public T getNullValue(DeserializationContext ctxt) throws JsonMappingException {
+        var clazz = defaultInstance.getClass();
+        if (Value.class.isAssignableFrom(clazz)) {
+            @SuppressWarnings("unchecked")
+            var nullValue =
+                    (T) Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
+            return nullValue;
+        }
+        return super.getNullValue(ctxt);
     }
 
     /**

--- a/jackson-module-protobuf/src/test/java/jacksonmodule/protobuf/ProtobufModuleTest.java
+++ b/jackson-module-protobuf/src/test/java/jacksonmodule/protobuf/ProtobufModuleTest.java
@@ -7,7 +7,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.Duration;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.NullValue;
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Struct;
 import com.google.protobuf.Timestamp;
+import com.google.protobuf.Value;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -279,6 +284,83 @@ class ProtobufModuleTest {
 
             // Assert
             assertThat(actualPet).isEqualTo(expectedPet);
+        }
+
+        @Test
+        @DisplayName("Should deserialize value message")
+        void shouldDeserializeValueMessage() {
+            // Arrange
+            String inputDoubleValue = "1.23";
+            DoubleValue expectedDoubleValue = DoubleValue.of(1.23);
+
+            String inputStringValue = "\"Hello, World!\"";
+            StringValue expectedStringValue = StringValue.of("Hello, World!");
+
+            String inputBoolValue = "true";
+            BoolValue expectedBoolValue = BoolValue.of(true);
+
+            String inputNullValue = "null";
+            NullValue expectedNullValue = NullValue.NULL_VALUE;
+
+            String inputValueOfString = "\"test value\"";
+            Value expectedValueValue =
+                    Value.newBuilder().setStringValue("test value").build();
+
+            String inputValueOfNumber = "42.5";
+            Value expectedValueNumber = Value.newBuilder().setNumberValue(42.5).build();
+
+            String inputValueOfBool = "true";
+            Value expectedValueBool = Value.newBuilder().setBoolValue(true).build();
+
+            String inputValueOfNull = "null";
+            Value expectedValueNull =
+                    Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
+
+            String inputValueOfList = "[\"item1\", 123, false, null]";
+            ListValue expectedListValue = ListValue.newBuilder()
+                    .addValues(Value.newBuilder().setStringValue("item1").build())
+                    .addValues(Value.newBuilder().setNumberValue(123).build())
+                    .addValues(Value.newBuilder().setBoolValue(false).build())
+                    .addValues(Value.newBuilder()
+                            .setNullValue(NullValue.NULL_VALUE)
+                            .build())
+                    .build();
+
+            String inputValueOfStruct = "{\"k1\": \"value\", \"k2\": 123, \"k3\": false, \"k4\": null}";
+            Struct expectedStructValue = Struct.newBuilder()
+                    .putFields("k1", Value.newBuilder().setStringValue("value").build())
+                    .putFields("k2", Value.newBuilder().setNumberValue(123).build())
+                    .putFields("k3", Value.newBuilder().setBoolValue(false).build())
+                    .putFields(
+                            "k4",
+                            Value.newBuilder()
+                                    .setNullValue(NullValue.NULL_VALUE)
+                                    .build())
+                    .build();
+
+            // Act
+            DoubleValue actualDoubleValue = readValue(inputDoubleValue, DoubleValue.class);
+            StringValue actualStringValue = readValue(inputStringValue, StringValue.class);
+            BoolValue actualBoolValue = readValue(inputBoolValue, BoolValue.class);
+            NullValue actualNullValue = readValue(inputNullValue, NullValue.class);
+            Value actualValueOfString = readValue(inputValueOfString, Value.class);
+            Value actualValueOfNumber = readValue(inputValueOfNumber, Value.class);
+            Value actualValueOfBool = readValue(inputValueOfBool, Value.class);
+            Value actualValueOfNull = readValue(inputValueOfNull, Value.class);
+            ListValue actualListValue = readValue(inputValueOfList, ListValue.class);
+            Struct actualStructValue = readValue(inputValueOfStruct, Struct.class);
+
+            // Assert
+            assertThat(actualDoubleValue).isEqualTo(expectedDoubleValue);
+            assertThat(actualStringValue).isEqualTo(expectedStringValue);
+            assertThat(actualBoolValue).isEqualTo(expectedBoolValue);
+            assertThat(actualNullValue).isEqualTo(expectedNullValue);
+            assertThat(actualValueOfString).isEqualTo(expectedValueValue);
+            assertThat(actualValueOfNumber).isEqualTo(expectedValueNumber);
+            assertThat(actualValueOfBool).isEqualTo(expectedValueBool);
+            assertThat(actualValueOfNull).isEqualTo(expectedValueNull);
+            assertThat(actualListValue).isEqualTo(expectedListValue);
+            assertThat(actualStructValue).isEqualTo(expectedStructValue);
         }
     }
 


### PR DESCRIPTION
This PR adds proper null value handling for protobuf enums and messages in the Jackson module.

## Changes Made

### ProtobufEnumDeserializer
- Added getNullValue override to handle NullValue enum properly
- Returns NullValue.NULL_VALUE when deserializing null values for NullValue enum type
- Falls back to parent implementation for other enum types

### ProtobufMessageDeserializer  
- Added getNullValue override to handle Value message type properly
- Returns Value with NullValue.NULL_VALUE when deserializing null values for Value message type
- Falls back to parent implementation for other message types

### Tests
- Added comprehensive test cases for various protobuf value types:
  - DoubleValue, StringValue, BoolValue deserialization
  - NullValue enum deserialization  
  - Value message deserialization with different value types (string, number, bool, null)
  - ListValue and Struct deserialization with mixed value types

## Benefits
- Proper null handling for Google protobuf well-known types
- Better compatibility with protobuf JSON format
- More robust deserialization for complex protobuf structures

## Testing
All existing tests pass, and new comprehensive tests have been added to verify the null value handling functionality.