### PR TITLE
Fix schema fallback to string for field names with a letter after a digit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,7 @@ plugins {
     id "org.springframework.boot" version "${springBootVersion}" apply false
     id "com.diffplug.spotless" version "${spotlessVersion}" apply false
     id "com.github.spotbugs" version "${spotbugsVersion}" apply false
-    // https://github.com/google/protobuf-gradle-plugin
-    id "com.google.protobuf" version "+" apply false
+    id "com.google.protobuf" version "${protobufPluginVersion}" apply false
     id "io.github.danielliu1123.deployer" version "${deployerVersion}"
 }
 
@@ -37,8 +36,6 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url = "https://repo.spring.io/snapshot" }
-        maven { url = "https://repo.spring.io/milestone" }
     }
 
     compileJava {
@@ -57,7 +54,7 @@ subprojects {
         testAnnotationProcessor("org.projectlombok:lombok:+")
         compileOnly("com.github.spotbugs:spotbugs-annotations:${spotbugsAnnotationsVersion}")
         // https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_framework_implementation_dependencies
-        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher:${junitLauncherVersion}")
     }
 
     test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.github.danielliu1123
-version=1.0.1-SNAPSHOT
+version=1.0.2-SNAPSHOT
 
 # Spring related
 # https://github.com/spring-projects/spring-boot
@@ -7,19 +7,24 @@ springBootVersion=4.0.6
 # https://github.com/springdoc/springdoc-openapi
 springDocsVersion=3.0.3
 # https://central.sonatype.com/artifact/com.google.protobuf/protobuf-java
-protobufVersion=4.34.1
+protobufVersion=4.35.1
+# https://github.com/google/protobuf-gradle-plugin
+protobufPluginVersion=0.10.0
 # https://central.sonatype.com/artifact/com.fasterxml.jackson.core/jackson-databind
-jacksonVersion=2.21.3
+jacksonVersion=2.22.0
 # https://central.sonatype.com/artifact/tools.jackson.core/jackson-databind
-jackson3Version=3.1.3
+jackson3Version=3.2.0
+# JUnit Platform launcher; align with the JUnit version brought in by spring-boot-starter-test
+# https://central.sonatype.com/artifact/org.junit.platform/junit-platform-launcher
+junitLauncherVersion=6.0.3
 
 # Code quality
 # https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless
-spotlessVersion=8.4.0
+spotlessVersion=8.8.0
 # https://plugins.gradle.org/plugin/com.github.spotbugs
-spotbugsVersion=6.5.4
+spotbugsVersion=6.5.8
 # https://github.com/spotbugs/spotbugs-gradle-plugin/blob/master/build.gradle.kts#L28
-spotbugsAnnotationsVersion=4.9.8
+spotbugsAnnotationsVersion=4.10.2
 
 # Publishing
 # https://github.com/DanielLiu1123/maven-deployer

--- a/springdoc-bridge-protobuf/src/main/java/springdocbridge/protobuf/ProtobufModelConverter.java
+++ b/springdoc-bridge-protobuf/src/main/java/springdocbridge/protobuf/ProtobufModelConverter.java
@@ -219,11 +219,11 @@ public class ProtobufModelConverter implements ModelConverter {
 
         String getterMethodName;
         if (fieldDescriptor.isMapField()) {
-            getterMethodName = "get" + underlineToPascal(fieldName) + "Map";
+            getterMethodName = "get" + fieldNameToGetterInfix(fieldName) + "Map";
         } else if (fieldDescriptor.isRepeated()) {
-            getterMethodName = "get" + underlineToPascal(fieldName) + "List";
+            getterMethodName = "get" + fieldNameToGetterInfix(fieldName) + "List";
         } else {
-            getterMethodName = "get" + underlineToPascal(fieldName);
+            getterMethodName = "get" + fieldNameToGetterInfix(fieldName);
         }
 
         try {
@@ -249,12 +249,41 @@ public class ProtobufModelConverter implements ModelConverter {
         return sb.toString();
     }
 
-    private static String underlineToPascal(String name) {
-        var n = underlineToCamel(name);
-        if (n.isBlank()) {
-            return n;
+    /**
+     * Converts a protobuf field name into the capitalized camelCase infix used by the generated
+     * Java getter/setter names (e.g. {@code "a1b64"} -> {@code "A1B64"}, so the getter is
+     * {@code getA1B64()}).
+     *
+     * <p>This replicates protobuf's own {@code UnderscoresToCamelCase} name mangling used by the
+     * Java code generator: the first letter is capitalized, the letter following an underscore is
+     * capitalized, and — crucially — the letter following a digit is also capitalized. A naive
+     * snake_case-to-PascalCase conversion misses the digit rule and produces a getter name that
+     * does not exist, which previously caused such fields to fall back to a generic schema.
+     *
+     * @see <a href="https://github.com/DanielLiu1123/springdoc-bridge/issues/21">Issue #21</a>
+     */
+    private static String fieldNameToGetterInfix(String name) {
+        var sb = new StringBuilder(name.length());
+        var capNext = true;
+        for (var i = 0; i < name.length(); i++) {
+            var c = name.charAt(i);
+            if (c >= 'a' && c <= 'z') {
+                sb.append(capNext ? Character.toUpperCase(c) : c);
+                capNext = false;
+            } else if (c >= 'A' && c <= 'Z') {
+                // Existing capitals are left as-is (protobuf only lowercases a leading capital
+                // when it is explicitly told not to capitalize the first letter).
+                sb.append(c);
+                capNext = false;
+            } else if (c >= '0' && c <= '9') {
+                sb.append(c);
+                capNext = true;
+            } else {
+                // Underscore or any other separator: capitalize the next letter.
+                capNext = true;
+            }
         }
-        return Character.toUpperCase(n.charAt(0)) + n.substring(1);
+        return sb.toString();
     }
 
     @SuppressWarnings("rawtypes")

--- a/springdoc-bridge-protobuf/src/test/java/springdocbridge/protobuf/ProtobufModelConverterTest.java
+++ b/springdoc-bridge-protobuf/src/test/java/springdocbridge/protobuf/ProtobufModelConverterTest.java
@@ -31,7 +31,6 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import java.lang.reflect.Type;
 import java.util.List;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.providers.ObjectMapperProvider;
@@ -40,20 +39,18 @@ import org.springframework.core.ResolvableType;
 import springdocbridge.protobuf.SpringDocBridgeProtobufProperties.SchemaNamingStrategy;
 import types.v1.DeprecatedTestMessage;
 import types.v1.EnumTestMessage;
+import types.v1.FieldNamingTestMessage;
 import types.v1.MapTestMessage;
 import types.v1.OneofTestMessage;
 import types.v1.OptionalTestMessage;
 import types.v1.RepeatedTestMessage;
 
-@DisplayName("ProtobufWellKnownTypeModelConverter Tests")
 class ProtobufModelConverterTest {
 
     @Nested
-    @DisplayName("Well-Known Types Schema Tests")
     class WellKnownTypesSchemaTests {
 
         @Test
-        @DisplayName("Should convert Timestamp to date-time string schema")
         void shouldConvertTimestampToDateTimeStringSchema() {
             var schema = resolve(Timestamp.class);
 
@@ -63,7 +60,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert Duration to string schema with pattern")
         void shouldConvertDurationToStringSchemaWithPattern() {
             var schema = resolve(Duration.class);
 
@@ -73,7 +69,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert BoolValue to boolean schema")
         void shouldConvertBoolValueToBooleanSchema() {
             var schema = resolve(BoolValue.class);
 
@@ -81,7 +76,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert Int32Value to integer schema")
         void shouldConvertInt32ValueToIntegerSchema() {
             var schema = resolve(Int32Value.class);
 
@@ -91,7 +85,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert StringValue to string schema")
         void shouldConvertStringValueToStringSchema() {
             var schema = resolve(StringValue.class);
 
@@ -100,11 +93,9 @@ class ProtobufModelConverterTest {
     }
 
     @Nested
-    @DisplayName("Special Types Schema Tests")
     class SpecialTypesSchemaTests {
 
         @Test
-        @DisplayName("Should convert Any to object schema with @type field")
         void shouldConvertAnyToObjectSchemaWithTypeField() {
             var schema = resolve(Any.class);
 
@@ -115,7 +106,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert Struct to object schema with additional properties")
         void shouldConvertStructToObjectSchemaWithAdditionalProperties() {
             var schema = resolve(Struct.class);
 
@@ -125,7 +115,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert ListValue to array schema")
         void shouldConvertListValueToArraySchema() {
             var schema = resolve(ListValue.class);
 
@@ -135,7 +124,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert FieldMask to string schema")
         void shouldConvertFieldMaskToStringSchema() {
             var schema = resolve(FieldMask.class);
 
@@ -143,7 +131,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert Empty to empty object schema")
         void shouldConvertEmptyToEmptyObjectSchema() {
             var schema = resolve(Empty.class);
 
@@ -151,7 +138,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert ByteString to base64 string schema")
         void shouldConvertByteStringToBase64StringSchema() {
             var schema = resolve(ByteString.class);
 
@@ -162,11 +148,9 @@ class ProtobufModelConverterTest {
     }
 
     @Nested
-    @DisplayName("Protobuf Enum Schema Tests")
     class ProtobufEnumSchemaTests {
 
         @Test
-        @DisplayName("Should remove UNRECOGNIZED from enum values")
         void shouldRemoveUnrecognizedFromEnumValues() {
             // Given
             var schema = resolve(EnumTestMessage.Enum.class);
@@ -179,11 +163,9 @@ class ProtobufModelConverterTest {
     }
 
     @Nested
-    @DisplayName("Protobuf repeated fields tests")
     class ProtobufRepeatedFieldsTests {
 
         @Test
-        @DisplayName("Should convert repeated string field to array schema")
         void shouldConvertRepeatedStringFieldToArraySchema() {
             var schema = resolve(RepeatedTestMessage.class);
 
@@ -204,10 +186,8 @@ class ProtobufModelConverterTest {
     }
 
     @Nested
-    @DisplayName("Required fields tests")
     class RequiredFieldsTests {
         @Test
-        @DisplayName("Should mark required fields by default")
         void shouldMarkRequiredFieldsByDefault() {
             var schema = resolve(OptionalTestMessage.class);
 
@@ -215,7 +195,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should mark oneof fields as optional")
         void shouldMarkOneofFieldsAsOptional() {
             var schema = resolve(OneofTestMessage.class);
 
@@ -229,10 +208,26 @@ class ProtobufModelConverterTest {
     }
 
     @Nested
-    @DisplayName("Deprecated fields tests")
+    class FieldNamingTests {
+
+        // https://github.com/DanielLiu1123/springdoc-bridge/issues/21
+        @Test
+        void shouldResolveFieldSchemasWhenLetterFollowsDigit() {
+            var schema = resolve(FieldNamingTestMessage.class);
+
+            // Protobuf capitalizes the letter after a digit for the generated getter
+            // (a1b64 -> getA1B64), which previously broke schema resolution and fell back to string.
+            assertThat(schema.getProperties()).containsKeys("a1b64", "a1b48", "my2ndValue", "normalField");
+            assertThat(schema.getProperties().get("a1b64").getTypes()).containsExactly("string");
+            assertThat(schema.getProperties().get("a1b48").getTypes()).containsExactly("string");
+            assertThat(schema.getProperties().get("my2ndValue").getTypes()).containsExactly("integer");
+            assertThat(schema.getProperties().get("normalField").getTypes()).containsExactly("string");
+        }
+    }
+
+    @Nested
     class DeprecatedFieldsTests {
         @Test
-        @DisplayName("Should mark deprecated fields")
         void shouldMarkDeprecatedFields() {
             // Given
             @SuppressWarnings("deprecation")
@@ -248,11 +243,9 @@ class ProtobufModelConverterTest {
     }
 
     @Nested
-    @DisplayName("Protobuf map fields tests")
     class ProtobufMapFieldsTests {
 
         @Test
-        @DisplayName("Should convert map with string values to object schema")
         void shouldConvertMapWithStringValuesToObjectSchema() {
             var schema = resolve(MapTestMessage.class);
 
@@ -263,7 +256,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert map with enum values to object schema")
         void shouldConvertMapWithEnumValuesToObjectSchema() {
             var schema = resolve(MapTestMessage.class);
 
@@ -274,7 +266,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert map with message values to object schema")
         void shouldConvertMapWithMessageValuesToObjectSchema() {
             var schema = resolve(MapTestMessage.class);
 
@@ -285,7 +276,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should convert map with int values to object schema")
         void showBeConvertMapWithIntValuesToObjectSchema() {
             var schema = resolve(MapTestMessage.class);
 
@@ -296,7 +286,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should be deprecated when using [deprecated = true] in proto")
         void shouldBeDeprecatedWhenUsingDeprecatedInProto() {
             var schema = resolve(MapTestMessage.class);
 
@@ -309,11 +298,9 @@ class ProtobufModelConverterTest {
     }
 
     @Nested
-    @DisplayName("Resolve List tests")
     class ResolveListTests {
 
         @Test
-        @DisplayName("Return null when resolve List without schemaProperty")
         void nullWhenResolveListWithoutSchemaProperty() {
 
             // This is why we need to set schemaProperty to true
@@ -331,7 +318,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should resolve List when set schemaProperty to true")
         void shouldResolveListWhenSetSchemaPropertyToTrue() {
             // Given
             var type = ResolvableType.forType(new ParameterizedTypeReference<List<String>>() {})
@@ -349,11 +335,9 @@ class ProtobufModelConverterTest {
     }
 
     @Nested
-    @DisplayName("Schema Naming Strategy Tests")
     class SchemaNamingStrategyTests {
 
         @Test
-        @DisplayName("Should use simple name when using Springdoc naming strategy and not using FQN")
         void shouldUseSimpleNameWhenUsingSpringdocNamingStrategyAndNotUsingFqn() {
             // Arrange
             var context = getModelConverterContext(SchemaNamingStrategy.SPRINGDOC, false);
@@ -366,7 +350,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should use FQN when using Springdoc naming strategy and using FQN")
         void shouldUseFqnWhenUsingSpringdocNamingStrategyAndUsingFqn() {
             // Arrange
             var context = getModelConverterContext(SchemaNamingStrategy.SPRINGDOC, true);
@@ -379,7 +362,6 @@ class ProtobufModelConverterTest {
         }
 
         @Test
-        @DisplayName("Should use protobuf name when using Protobuf naming strategy")
         void shouldUseProtobufNameWhenUsingProtobufNamingStrategy() {
             // Arrange
             var context = getModelConverterContext(SchemaNamingStrategy.PROTOBUF, true);

--- a/springdoc-bridge-protobuf/src/test/proto/types/v1/field_naming.proto
+++ b/springdoc-bridge-protobuf/src/test/proto/types/v1/field_naming.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package types.v1;
+
+option java_multiple_files = true;
+option java_package = "types.v1";
+
+// Reproduces https://github.com/DanielLiu1123/springdoc-bridge/issues/21
+// Field names where a letter immediately follows a digit trigger protobuf's
+// camelCase rule that capitalizes the letter after a digit, e.g.
+// "a1b64" -> getter getA1B64().
+message FieldNamingTestMessage {
+  string a1b64 = 1;
+  string a1b48 = 2;
+  int32 my2nd_value = 3;
+  string normal_field = 4;
+}


### PR DESCRIPTION
## Problem

Fixes #21.

When a protobuf field name has a letter immediately following a digit (e.g. `a1b64`, `a1b48`, `my2nd_value`), the generated OpenAPI schema for the whole message falls back to a generic `string`.

## Root cause

`ProtobufModelConverter` derives the Java getter name from the field name to reflectively read the field's return type. It used a naive snake_case → PascalCase conversion that only capitalizes after underscores. Protobuf's own Java code generator (`UnderscoresToCamelCase`) **also capitalizes the letter after a digit**, so the real getters are:

| field name | derived (before) | actual protobuf getter |
|---|---|---|
| `a1b64` | `getA1b64` ❌ | `getA1B64` |
| `a1b48` | `getA1b48` ❌ | `getA1B48` |
| `my2nd_value` | `getMy2ndValue` ❌ | `getMy2NdValue` |
| `normal_field` | `getNormalField` ✅ | `getNormalField` |

The mismatched name threw `NoSuchMethodException`, aborting schema resolution and letting the message fall back to `string`.

## Fix

Replace the getter-name derivation with a faithful port of protobuf's `UnderscoresToCamelCase` (capitalize after underscores **and** digits).

The JSON property name is intentionally left unchanged: the default `JsonFormat.printer()` serializes using the JSON name, which does **not** capitalize after digits (so `a1b64` stays `a1b64` in the payload). Only the getter lookup needed fixing.